### PR TITLE
Support @ TODO, @ FIXME, @ BUG, etc.

### DIFF
--- a/bin/fixme.js
+++ b/bin/fixme.js
@@ -16,37 +16,37 @@ var ignoredDirectories  = ['node_modules/**', '.git/**', '.hg/**'],
     skipChecks          = [],
     messageChecks       = {
       note: {
-        regex:    /(?:^|[^:])\/[/*]\s*NOTE\b\s*(?:\(([^:]*)\))*\s*:?\s*(.*)/i,
+        regex:    /(?:^|[^:])\/[/*]\s*@?NOTE\b\s*(?:\(([^:]*)\))*\s*:?\s*(.*)/i,
         label:    ' ✐ NOTE',
         colorer:  chalk.green
       },
       optimize: {
-        regex:    /(?:^|[^:])\/[/*]\s*OPTIMIZE\b\s*(?:\(([^:]*)\))*\s*:?\s*(.*)/i,
+        regex:    /(?:^|[^:])\/[/*]\s*@?OPTIMIZE\b\s*(?:\(([^:]*)\))*\s*:?\s*(.*)/i,
         label:    ' ↻ OPTIMIZE',
         colorer:  chalk.blue
       },
       todo: {
-        regex:    /(?:^|[^:])\/[/*]\s*TODO\b\s*(?:\(([^:]*)\))*\s*:?\s*(.*)/i,
+        regex:    /(?:^|[^:])\/[/*]\s*@?TODO\b\s*(?:\(([^:]*)\))*\s*:?\s*(.*)/i,
         label:    ' ✓ TODO',
         colorer:  chalk.magenta
       },
       hack: {
-        regex:    /(?:^|[^:])\/[/*]\s*HACK\b\s*(?:\(([^:]*)\))*\s*:?\s*(.*)/i,
+        regex:    /(?:^|[^:])\/[/*]\s*@?HACK\b\s*(?:\(([^:]*)\))*\s*:?\s*(.*)/i,
         label:    ' ✄ HACK',
         colorer:  chalk.yellow
       },
       xxx: {
-        regex:    /(?:^|[^:])\/[/*]\s*XXX\b\s*(?:\(([^:]*)\))*\s*:?\s*(.*)/i,
+        regex:    /(?:^|[^:])\/[/*]\s*@?XXX\b\s*(?:\(([^:]*)\))*\s*:?\s*(.*)/i,
         label:    ' ✗ XXX',
         colorer:  chalk.black.bgYellow
       },
       fixme: {
-        regex:    /(?:^|[^:])\/[/*]\s*FIXME\b\s*(?:\(([^:]*)\))*\s*:?\s*(.*)/i,
+        regex:    /(?:^|[^:])\/[/*]\s*@?FIXME\b\s*(?:\(([^:]*)\))*\s*:?\s*(.*)/i,
         label:    ' ☠ FIXME',
         colorer:  chalk.red
       },
       bug: {
-        regex:    /(?:^|[^:])\/[/*]\s*BUG\b\s*(?:\(([^:]*)\))*\s*:?\s*(.*)/i,
+        regex:    /(?:^|[^:])\/[/*]\s*@?BUG\b\s*(?:\(([^:]*)\))*\s*:?\s*(.*)/i,
         label:    ' ☢ BUG',
         colorer:  chalk.white.bgRed
       }


### PR DESCRIPTION
I've noticed that fixme doesn't pick up on `// @TODO` comments and the like, so this is a simple regex modification to allow for an @ immediately preceding the keyword.